### PR TITLE
PNG export options

### DIFF
--- a/pewpew/__init__.py
+++ b/pewpew/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.4.3"
+__version__ = "1.4.4"
 __loglevel__ = logging.DEBUG
 
 logging.captureWarnings(True)

--- a/pewpew/graphics/export.py
+++ b/pewpew/graphics/export.py
@@ -33,8 +33,6 @@ def paint_colorbar(
     vrange: Tuple[float, float],
     unit: str | None = None,
 ) -> None:
-    painter.save()
-
     _data = np.arange(256, dtype=np.uint8)
     _data[0] = 1
     cbar = QtGui.QImage(_data, 256, 1, 256, QtGui.QImage.Format_Indexed8)
@@ -43,12 +41,8 @@ def paint_colorbar(
 
     painter.drawImage(rect, cbar)
 
+    painter.save()
     painter.setRenderHint(QtGui.QPainter.Antialiasing)
-    pen = QtGui.QPen(QtCore.Qt.black, 2.0)
-    pen.setCosmetic(True)
-    painter.setPen(pen)
-    painter.setBrush(QtGui.QBrush(QtCore.Qt.GlobalColor.white))
-
     fm = painter.fontMetrics()
 
     path = path_for_colorbar_labels(painter.font(), vrange[0], vrange[1], rect.width())
@@ -98,10 +92,6 @@ def paint_scalebar(
     scale: float,
 ) -> None:
     painter.save()
-    pen = QtGui.QPen(QtCore.Qt.black, 2.0)
-    pen.setCosmetic(True)
-    painter.setPen(pen)
-    painter.setBrush(QtGui.QBrush(QtCore.Qt.GlobalColor.white))
     painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing)
 
     rect = position_for_alignment(parent_rect, rect, alignment)
@@ -125,11 +115,12 @@ def paint_scalebar(
     # Draw the bar
     bar = QtCore.QRectF(
         rect.center().x() - width / 2.0,
-        rect.top() + fm.height(),
+        rect.top() + fm.height() + fm.lineWidth(),
         width,
-        fm.xHeight() / 2.0,
+        fm.xHeight() / 4.0,
     )
     painter.drawRect(bar)
+    painter.fillRect(bar, painter.brush())
     painter.restore()
 
 
@@ -145,6 +136,8 @@ def generate_laser_image(
     | QtCore.Qt.AlignmentFlag.AlignLeft,
     colorbar: bool = True,
     raw: bool = False,
+    size: QtCore.QSize | None = None,
+    dpi: int = 96,
 ) -> QtGui.QImage:
     data = laser.get(element, calibrate=options.calibrate, flat=True)
     data = np.ascontiguousarray(data)
@@ -159,35 +152,49 @@ def generate_laser_image(
     image = array_to_image(data)
     image.setColorTable(table)
     image.setColorCount(len(table))
-
     if raw:
         return image
 
-    fm = QtGui.QFontMetrics(options.font)
-    xh = fm.xHeight()
-    image = image.scaled(image.size() * 2.0)
-    size = image.size()
+    if size is None:
+        size = image.size() * 2
 
+    font = QtGui.QFont(options.font)
+    font_scale = dpi / QtGui.QFontMetrics(options.font).fontDpi()
+    font.setPointSizeF(font.pointSize() * font_scale)
+    fm = QtGui.QFontMetrics(font)
+    xh = fm.xHeight()
+
+    output_size = size
     if colorbar:  # make room for colorbar
-        size = size.grownBy(QtCore.QMargins(0, 0, 0, xh + xh / 2.0 + fm.height()))
+        colorbar_height = xh + xh / 2.0 + fm.height()
         unit = laser.calibration[element].unit
         if unit is not None and len(unit) > 0:
-            size = size.grownBy(QtCore.QMargins(0, 0, 0, fm.height()))
+            colorbar_height += fm.height()
+        output_size = output_size.grownBy(QtCore.QMargins(0, 0, 0, colorbar_height))
 
-    pixmap = QtGui.QPixmap(size)
+    pixmap = QtGui.QPixmap(output_size)
     pixmap.fill(QtCore.Qt.GlobalColor.transparent)
 
     painter = QtGui.QPainter(pixmap)
-    painter.setFont(options.font)
+    painter.setFont(font)
+    painter.setBrush(QtGui.QBrush(QtCore.Qt.GlobalColor.white))
+
+    pen = QtGui.QPen(QtCore.Qt.GlobalColor.black, fm.lineWidth())
+    pen.setCosmetic(True)
+    painter.setPen(pen)
 
     # Draw the image
-    painter.drawImage(image.rect(), image, image.rect())
+    painter.drawImage(QtCore.QRect(QtCore.QPoint(0, 0), size), image)
+
+    text_bounds = QtCore.QRectF(QtCore.QPointF(0, 0), size)
+    pad = fm.lineWidth() * 2.0
+    text_bounds.adjust(pad, pad, -pad, -pad)
 
     if colorbar:
         paint_colorbar(
             painter,
             QtCore.QRectF(
-                image.rect().left(), image.rect().bottom() + xh / 2.0, image.width(), xh
+                0.0, pixmap.height() - colorbar_height + xh / 2.0, pixmap.width(), xh
             ),
             table,
             (vmin, vmax),
@@ -196,26 +203,22 @@ def generate_laser_image(
 
     # Draw the element label
     if label_alignment is not None:
-        rect = painter.boundingRect(
-            image.rect().adjusted(xh, xh, -xh, -xh), label_alignment, element
-        )
+        rect = painter.boundingRect(text_bounds, label_alignment, element)
         path = QtGui.QPainterPath()
         path.addText(rect.left(), rect.top() + fm.ascent(), painter.font(), element)
 
-        pen = QtGui.QPen(QtCore.Qt.black, 2.0)
-        pen.setCosmetic(True)
         painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing)
-        painter.strokePath(path, pen)
-        painter.fillPath(path, QtGui.QBrush(QtCore.Qt.GlobalColor.white))
+        painter.strokePath(path, painter.pen())
+        painter.fillPath(path, painter.brush())
 
     # Draw the scale-bar
     if scalebar_alignment is not None:
         x0, x1, y0, y1 = laser.extent
-        scale = (x1 - x0) / image.rect().width()
+        scale = (x1 - x0) / pixmap.width()
         paint_scalebar(
             painter,
             QtCore.QRectF(0, 0, xh * 10.0, fm.height()),
-            image.rect().adjusted(xh, xh, -xh, -xh),
+            text_bounds,
             scalebar_alignment,
             scale,
         )
@@ -241,6 +244,8 @@ def generate_rgb_laser_image(
     | QtCore.Qt.AlignmentFlag.AlignLeft,
     raw: bool = False,
     subtractive: bool = False,
+    size: QtCore.QSize | None = None,
+    dpi: int = 96,
 ) -> QtGui.QImage:
     data = np.zeros((*laser.shape[:2], 3))
     for i, (element, color, (pmin, pmax)) in enumerate(zip(elements, colors, ranges)):
@@ -267,38 +272,48 @@ def generate_rgb_laser_image(
     if raw:
         return image
 
-    fm = QtGui.QFontMetrics(options.font)
-    xh = fm.xHeight()
-    image = image.scaled(image.size() * 2.0)
-    size = image.size()
+    if size is None:
+        size = image.size() * 2
+    output_size = size
 
-    pixmap = QtGui.QPixmap(size)
+    font = QtGui.QFont(options.font)
+    font_scale = dpi / QtGui.QFontMetrics(options.font).fontDpi()
+    font.setPointSizeF(font.pointSize() * font_scale)
+    fm = QtGui.QFontMetrics(font)
+    xh = fm.xHeight()
+
+    pixmap = QtGui.QPixmap(output_size)
     pixmap.fill(QtCore.Qt.GlobalColor.transparent)
 
     painter = QtGui.QPainter(pixmap)
-    painter.setFont(options.font)
+    painter.setFont(font)
+    painter.setBrush(QtGui.QBrush(QtCore.Qt.GlobalColor.white))
+
+    pen = QtGui.QPen(QtCore.Qt.GlobalColor.black, 2.0 * font_scale)
+    pen.setCosmetic(True)
+    painter.setPen(pen)
 
     # Draw the image
-    painter.drawImage(image.rect(), image, image.rect())
+    painter.drawImage(QtCore.QRect(QtCore.QPoint(0, 0), size), image)
+
+    text_bounds = QtCore.QRectF(QtCore.QPointF(0, 0), size)
+    pad = fm.lineWidth() * 2.0
+    text_bounds.adjust(pad, pad, -pad, -pad)
 
     # Draw the element label
     if label_alignment is not None:
         width = max(fm.boundingRect(text).width() for text in elements)
         rect = QtCore.QRectF(0, 0, width, fm.height() * len(elements))
 
-        rect = position_for_alignment(
-            image.rect().adjusted(xh, xh, -xh, -xh), rect, label_alignment
-        )
+        rect = position_for_alignment(text_bounds, rect, label_alignment)
 
         painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing)
-        pen = QtGui.QPen(QtCore.Qt.black, 2.0)
-        pen.setCosmetic(True)
 
         pos = rect.topLeft()
         for element, color in zip(elements, colors):
             path = QtGui.QPainterPath()
             path.addText(pos.x(), pos.y() + fm.ascent(), painter.font(), element)
-            painter.strokePath(path, pen)
+            painter.strokePath(path, painter.pen())
             painter.fillPath(path, QtGui.QBrush(color))
             pos.setY(pos.y() + fm.height())
 
@@ -309,16 +324,14 @@ def generate_rgb_laser_image(
         paint_scalebar(
             painter,
             QtCore.QRectF(0, 0, xh * 10.0, fm.height()),
-            image.rect().adjusted(xh, xh, -xh, -xh),
+            text_bounds,
             scalebar_alignment,
             scale,
         )
 
     # Draw the color Venn
     if venn_alignment is not None:
-        paint_color_venn(
-            painter, image.rect().adjusted(xh, xh, -xh, -xh), venn_alignment, colors
-        )
+        paint_color_venn(painter, text_bounds, venn_alignment, colors)
 
     painter.end()
     return pixmap.toImage()

--- a/pewpew/graphics/util.py
+++ b/pewpew/graphics/util.py
@@ -90,9 +90,9 @@ def path_for_colorbar_labels(
         xpos = v * width / vrange
         text_pos = xpos - text_width / 2.0
         if text_pos < 0.0:
-            text_pos = fm.lineWidth() + fm.leftBearing(text[0])
+            text_pos = fm.lineWidth()
         elif text_pos + text_width > width:
-            text_pos = width - text_width - fm.lineWidth() - fm.rightBearing(text[-1])
+            text_pos = width - text_width - fm.lineWidth()
         path.addText(text_pos, fm.ascent(), font, text)
 
         xpos -= check_width / 2.0

--- a/pewpew/graphics/util.py
+++ b/pewpew/graphics/util.py
@@ -71,7 +71,7 @@ def shortest_label(
 
 
 def path_for_colorbar_labels(
-    font: QtGui.QFont, vmin: float, vmax: float, width: float
+    font: QtGui.QFont, vmin: float, vmax: float, width: float, pen_width: float = 1.0
 ) -> QtGui.QPainterPath:
     vrange = vmax - vmin
     fm = QtGui.QFontMetrics(font)
@@ -97,9 +97,9 @@ def path_for_colorbar_labels(
 
         xpos -= check_width / 2.0
         if xpos < 0.0:
-            xpos = 1.0
+            xpos = pen_width / 2.0
         elif xpos + check_width > width:
-            xpos = width - check_width - 1.0
+            xpos = width - check_width - pen_width / 2.0
         path.addRect(xpos, -check_width, check_width, check_width * 2.0)
 
     return path

--- a/pewpew/widgets/exportdialogs.py
+++ b/pewpew/widgets/exportdialogs.py
@@ -616,6 +616,8 @@ class ExportDialog(_ExportDialogBase):
                         size=size,
                         dpi=option.dpi(),
                     )
+                    image.setDotsPerMeterX(option.dpi() * 39.37007874)
+                    image.setDotsPerMeterY(option.dpi() * 39.37007874)
                     image.save(str(path.absolute()))
             else:
                 if element is not None and element in laser.elements:
@@ -631,6 +633,8 @@ class ExportDialog(_ExportDialogBase):
                         size=size,
                         dpi=option.dpi(),
                     )
+                    image.setDotsPerMeterX(option.dpi() * 39.37007874)
+                    image.setDotsPerMeterY(option.dpi() * 39.37007874)
                     image.save(str(path.absolute()))
         elif option.ext == ".vti":
             spacing = option.spacing()


### PR DESCRIPTION
Add scale (size) and DPI options to the PNG export, for more 'publication ready' figures.
- Improved the scaling of fonts in PNG images
- Improved the positioning of labels and the scalebar
- Improved the positioning of right side colorbar labels